### PR TITLE
chore: Add AGENTS.md for dev environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+This is a Python MCP (Model Context Protocol) server for accessing Federal Reserve Economic Data (FRED). It exposes 10 tools via `fastmcp` that wrap the `fred-py-api` library. Single-service project with no databases or external infrastructure beyond the FRED API.
+
+### Required secrets
+
+- `FRED_API_KEY` — 32-character API key from <https://fred.stlouisfed.org/docs/api/api_key.html>. Must be set before running the server; the `fred-py-api` client validates key length at import time.
+
+### Running the server
+
+```bash
+# SSE mode (preferred for testing)
+FRED_API_KEY=$FRED_API_KEY MCP_SERVER_TRANSPORT=sse MCP_SERVER_PORT=8000 MCP_SERVER_HOST=0.0.0.0 fred-mcp
+
+# stdio mode (default, for MCP client integration)
+FRED_API_KEY=$FRED_API_KEY fred-mcp
+```
+
+### Linting
+
+```bash
+black --check --target-version py312 src/
+```
+
+The repo has pre-existing formatting deviations (extra blank lines) that `black` flags. This is a known upstream style choice.
+
+### Dependency compatibility
+
+The project depends on `fastmcp~=2.3.4`. At the time of writing, `pydantic>=2.12` causes a `TypeError: cannot specify both default and default_factory` crash at import time due to a pydantic/fastmcp incompatibility. Pin `pydantic>=2.11,<2.12` if this surfaces. The update script handles this automatically.
+
+### Testing
+
+No automated test suite exists in the repository. To verify the server works, start it in SSE mode and interact via the MCP JSON-RPC protocol over `/sse` and the session-specific `/messages/` endpoint.
+
+### Project layout
+
+```
+src/fred_mcp/
+  main.py              — Entry point, FastMCP server setup, transport config
+  series/mcp.py        — 10 FRED series tools (search, observations, tags, etc.)
+  common/types.py      — TypeAlias definitions for FRED API parameters
+pyproject.toml         — Build config, dependencies, black config (line-length=79)
+Dockerfile             — Alpine-based container image
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,45 +4,62 @@
 
 ### Overview
 
-This is a Python MCP (Model Context Protocol) server for accessing Federal Reserve Economic Data (FRED). It exposes 10 tools via `fastmcp` that wrap the `fred-py-api` library. Single-service project with no databases or external infrastructure beyond the FRED API.
+A Python MCP server (v1.0.0) for FRED economic data built on FastMCP 3.x. Exposes **31 tools** across five domains (series, categories, releases, sources, tags) via `fastmcp` wrapping `fred-py-api`. Single-service project with no databases or external infrastructure beyond the FRED API.
 
 ### Required secrets
 
-- `FRED_API_KEY` — 32-character API key from <https://fred.stlouisfed.org/docs/api/api_key.html>. Must be set before running the server; the `fred-py-api` client validates key length at import time.
+- `FRED_API_KEY` — 32-character API key from <https://fredaccount.stlouisfed.org/apikey>. Required for stdio transport; optional for HTTP transports (clients can send via `X-FRED-API-Key` header instead).
 
 ### Running the server
 
 ```bash
-# SSE mode (preferred for testing)
-FRED_API_KEY=$FRED_API_KEY MCP_SERVER_TRANSPORT=sse MCP_SERVER_PORT=8000 MCP_SERVER_HOST=0.0.0.0 fred-mcp
+# streamable-http mode (preferred for testing, default in Docker)
+FRED_API_KEY=$FRED_API_KEY MCP_SERVER_TRANSPORT=streamable-http MCP_SERVER_PORT=8000 MCP_SERVER_HOST=0.0.0.0 fred-mcp
 
 # stdio mode (default, for MCP client integration)
 FRED_API_KEY=$FRED_API_KEY fred-mcp
 ```
 
-### Linting
+The streamable-http endpoint is at `http://localhost:8000/mcp`.
+
+### Linting and testing
+
+Per the README `Development` section:
 
 ```bash
-black --check --target-version py312 src/
+ruff check src tests
+pytest
 ```
-
-The repo has pre-existing formatting deviations (extra blank lines) that `black` flags. This is a known upstream style choice.
 
 ### Dependency compatibility
 
-The project depends on `fastmcp~=2.3.4`. At the time of writing, `pydantic>=2.12` causes a `TypeError: cannot specify both default and default_factory` crash at import time due to a pydantic/fastmcp incompatibility. Pin `pydantic>=2.11,<2.12` if this surfaces. The update script handles this automatically.
+When installing, `fastmcp-slim` (a dependency of `fastmcp`) must install its source `.py` files alongside `.pyc` files. If `from fastmcp.exceptions import ToolError` fails with `ModuleNotFoundError`, run:
 
-### Testing
+```bash
+pip install --force-reinstall fastmcp-slim fastmcp
+```
 
-No automated test suite exists in the repository. To verify the server works, start it in SSE mode and interact via the MCP JSON-RPC protocol over `/sse` and the session-specific `/messages/` endpoint.
+This resolves a packaging race condition where `.py` source files are missing from the `fastmcp/` namespace directory.
 
 ### Project layout
 
 ```
 src/fred_mcp/
-  main.py              — Entry point, FastMCP server setup, transport config
-  series/mcp.py        — 10 FRED series tools (search, observations, tags, etc.)
+  main.py              — Entry point, mounts sub-servers, transport config
+  config.py            — Settings dataclass, env var parsing
+  credentials.py       — API key resolution (env var or HTTP header)
+  series/tools.py      — 10 series tools
+  categories/tools.py  — 6 category tools
+  releases/tools.py    — 9 release tools
+  sources/tools.py     — 3 source tools
+  tags/tools.py        — 3 tag tools
+  common/tools.py      — Shared call_fred helper
+  common/errors.py     — ToolError wrapper
   common/types.py      — TypeAlias definitions for FRED API parameters
-pyproject.toml         — Build config, dependencies, black config (line-length=79)
+tests/
+  test_tools.py        — Series tool tests + 31-tool count assertion
+  test_credentials.py  — API key resolution and settings tests
+  test_modules.py      — Parametrized module delegation tests
+pyproject.toml         — Build config, dependencies, ruff/pytest config
 Dockerfile             — Alpine-based container image
 ```


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud specific instructions for the v1.0.0 codebase (FastMCP 3.x refactor), covering:

- Required secrets (`FRED_API_KEY`)
- How to run the MCP server (streamable-http and stdio modes)
- Linting with `ruff` and testing with `pytest`
- Known `fastmcp-slim` packaging issue and workaround
- Full project layout (31 tools across 5 domains)

**Environment verification:**

All 31 tools listed and tested via the FastMCP client. GDP series, observations, unemployment rate search, categories, and sources all queried successfully.

[mcp_server_v1_test.log](https://cursor.com/agents/bc-074772ed-b82d-4cae-b8af-797447da5f0c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmcp_server_v1_test.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-074772ed-b82d-4cae-b8af-797447da5f0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-074772ed-b82d-4cae-b8af-797447da5f0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

